### PR TITLE
Request version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "event-stream": "~3.1.5",
     "vinyl": "~0.2.3",
-    "request": "~2.36.0",
+    "request": "~2.58.0",
     "through2": "~0.5.1",
     "node.extend": "~1.1.2"
   },


### PR DESCRIPTION
Request has a dependency to a vulnerable version of qs:

* https://nodesecurity.io/advisories/qs_dos_extended_event_loop_blocking
* https://nodesecurity.io/advisories/qs_dos_memory_exhaustion

I have a job in my continuous integration process that checks all packages used by my apps, and this one fails the build because of this dependency.

Updating to the latest version of request does the job.